### PR TITLE
feat(backend) Set Reload Interval To Reduce Calls to Cloud File Systems

### DIFF
--- a/backend/src/crd/controller/viewer/reconciler/reconciler.go
+++ b/backend/src/crd/controller/viewer/reconciler/reconciler.go
@@ -196,6 +196,10 @@ func setPodSpecForTensorboard(view *viewerV1beta1.Viewer, s *corev1.PodSpec) {
 	} else {
 		c.Args = append(c.Args, fmt.Sprintf("--logdir=%s", view.Spec.TensorboardSpec.LogDir))
 	}
+	// Set a reload interval of two minutes because the default of 5 seconds costs can be very
+	// high when pulling data from Cloud Storage systems. See the tensorboard bug about reading
+	// from s3.  https://github.com/tensorflow/tensorboard/issues/6564
+	c.Args = append(c.Args, "--reload_interval=120")
 
 	c.Ports = []corev1.ContainerPort{
 		{ContainerPort: viewerTargetPort},


### PR DESCRIPTION
**Description of your changes:**
The default reload interval of 5.0s can be very expensive for cloud file systems where each LIST and HEAD operation is billed.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

