### PR TITLE
(feat) Set Sagemaker Component to Adaptive Client

### DIFF
--- a/components/aws/sagemaker/common/boto3_manager.py
+++ b/components/aws/sagemaker/common/boto3_manager.py
@@ -103,7 +103,7 @@ class Boto3Manager(object):
         session = Boto3Manager._get_boto3_session(region, assume_role_arn)
         session_config = Config(
             user_agent=f"sagemaker-on-kubeflow-pipelines-v{component_version}",
-            retries={"max_attempts": 10, "mode": "standard"},
+            retries={"max_attempts": 10, "mode": "adaptive"},
         )
         client = session.client(
             "sagemaker",

--- a/components/aws/sagemaker/requirements.txt
+++ b/components/aws/sagemaker/requirements.txt
@@ -4,3 +4,4 @@ sagemaker==2.1.0
 pathlib2==2.3.5
 pyyaml==5.4
 mypy-extensions==0.4.3
+protobuf==3.20.*


### PR DESCRIPTION
**Description of your changes:**
Set the Sagemaker client to adaptive so that it will retry based on information AWS passes back. This should improve the retry logic and allow the polling of training jobs to overcome rate limiting.

To make this work pinning protoc is required as the newer library doesn't work with the sagemaker client as part of boto3==1.14.12.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 